### PR TITLE
CLI tool for quick enrollment and minor changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.cer
 *.key
 /src/openbanking_tpp_proxy/__pycache__/
+build/
+dist/
+src/openbanking_tpp_client_python.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build/
 dist/
 src/openbanking_tpp_client_python.egg-info/
+src/__pycache__/

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ CLI script provides usefull utility to perform TPP Certificate upload.
 To use it properly.
 #### Usage
 
-To enroll the certificates use cli script below, changing parametes to real ones. Example:
+To enroll the certificates from the shell use cli script below. Please change parameters to real ones.
+
+**Example**
 
 ```bash
 python enroll_certificates.py \

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ the TPP is authorised to use.
 
 ## Installation
 
-To install package use:
+To install dependencies use `setup.py` script.
 
 ```bash
-python setup.py
+python setup.py install
 ```
 
 ### Purpose

--- a/README.md
+++ b/README.md
@@ -67,3 +67,32 @@ enrollment_response = proxy.enroll_certificates("https://some.gateway.url/eidas/
 ```
 
 The sample usage can be found here: [app.py](src/app.py)
+
+### CLI usage
+
+CLI script provides usefull utility to perform TPP Certificate upload.
+To use it properly.
+#### Usage
+
+To enroll the certificates use cli script below, changing parametes to real ones. Example:
+
+```bash
+python enroll_certificates.py \
+  --api_url http://example.com
+  --tpp_id "NO-12345-ABC" \
+  --tpp_name "Awesome TPP" \
+  --qwac_cert "qwac_cert.cer" \
+  --qwac_key "qwac_key.key" \
+  --qseal_cert "qseal_cert.cer" \
+  --qseal_key "qseal_key.key" \
+  --intermediate_cert "intermediate.cer" \
+  --root_cert "root.cer"
+```
+
+#### Help
+
+To display help and information about arguments.
+
+```bash
+python enroll_certificates.py -h
+```

--- a/README.md
+++ b/README.md
@@ -1,68 +1,69 @@
 # Third Party Provider (TPP) client library Python version
 
-
 ## PSD2 - background and context information
 
 With **[PSD2](https://en.wikipedia.org/wiki/Payment_Services_Directive#Revised_Directive_on_Payment_Services_(PSD2))** the European Union has published a [new directive on payment services in the
-internal market](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32015L2366). Member States were required to adopt this directive into their national law by the 
-13th of January 2018. **PSD2** contains regulations of new services to be operated by so 
-called **Third Party Payment Service Providers (TPP)** on behalf of a Payment Service User (PSU). 
+internal market](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32015L2366). Member States were required to adopt this directive into their national law by the
+13th of January 2018. **PSD2** contains regulations of new services to be operated by so
+called **Third Party Payment Service Providers (TPP)** on behalf of a Payment Service User (PSU).
 The ideal behind this is enbling the consumers (PSUs) to access their accounts in the manner they prefer
 not being tied to one bank's interface.
 
-In order to be able to operate the new services for the PSUs a **TPP** needs to access the PSU's accounts, 
+In order to be able to operate the new services for the PSUs a **TPP** needs to access the PSU's accounts,
 which is usually managed by another PSP called the Account Servicing Payment Service Provider (ASPSP).
 
 ## TPP - transport layer requirements
-The communication between the TPP and the ASPSP is always secured by using a TLSconnection 
-using TLS version 1.2 or higher. This TLS-connection is set up by the TPP. It is not necessary 
-to set up a new TLS-connection for each transaction, however the ASPSP might terminate an existing 
+
+The communication between the TPP and the ASPSP is always secured by using a TLSconnection
+using TLS version 1.2 or higher. This TLS-connection is set up by the TPP. It is not necessary
+to set up a new TLS-connection for each transaction, however the ASPSP might terminate an existing
 TLS-connection if required by its security setting.
 
 The TLS-connection has to be established always including client (i.e. TPP) authentication.
 For this authentication the TPP has to use a qualified certificate for website authentication.
-This qualified certificate has to be issued by a qualified trust service provider according 
+This qualified certificate has to be issued by a qualified trust service provider according
 to the [eIDAS regulation](https://en.wikipedia.org/wiki/EIDAS) (eIDAS). The content of the certificate has to be compliant with the
-requirements of (EBA-RTS). The certificate of the TPP has to indicate all roles 
+requirements of (EBA-RTS). The certificate of the TPP has to indicate all roles
 the TPP is authorised to use.
 
 ## TPP client library
 
-### Purpose 
+## Installation
+
+To install package use:
+
+```bash
+python setup.py
+```
+
+### Purpose
 
 This utility library helps TPP developers to properly configure and establish a secure connection.
-It also addresses all HTTP headers- and message signing- related requirements. 
+It also addresses all HTTP headers- and message signing- related requirements.
 
 ### Basics
 
-First, create Proxy class and provide Website Authentication Certificate and Key (wac) and signing (seal) 
-client certificate and key file paths. Tke certificates and keys should be in RSA format (*.cer, *.key). 
-For seal key the library supports password encryption however passwords are not supported for wac key.   
+First, create Proxy class and provide Website Authentication Certificate and Key (wac) and signing (seal)
+client certificate and key file paths. Tke certificates and keys should be in RSA format (*.cer, *.key).
+For seal key the library supports password encryption however passwords are not supported for wac key.
 
 ```python
-
-    from openbanking_tpp_proxy.proxy import Proxy
-    proxy = Proxy("qwac_cert.cer", "qwac_key.key", "qseal_cert.cer", "qseal_key.key")
-
+from openbanking_tpp_proxy.proxy import Proxy
+proxy = Proxy("qwac_cert.cer", "qwac_key.key", "qseal_cert.cer", "qseal_key.key")
 ```
 
-Next, use python class to handle communication 
+Next, use python class to handle communication
+
 ```python
-    
-    response = proxy.proxy_request("GET", "https://some.gateway.url/eidas/1.0/v1/consents/health-check")
-
+response = proxy.proxy_request("GET", "https://some.gateway.url/eidas/1.0/v1/consents/health-check")
 ```
+
 The proxy client uses Python Requests HTTP Library where returned response is a part of.
-The Proxy class also supports the tpp certificate enrollment process provided in constructor. 
+The Proxy class also supports the tpp certificate enrollment process provided in constructor.
 The sample call looks as follows:
 
 ```python
-    
-    enrolmentResponse = proxy.enroll_certificates("https://some.gateway.url/eidas/1.0/v1/enrollment", "intermediate.cer", "root.cer", "TPP_ID" , "Commertial name")
-
+enrollment_response = proxy.enroll_certificates("https://some.gateway.url/eidas/1.0/v1/enrollment", "intermediate.cer", "root.cer", "TPP_ID" , "Commertial name")
 ```
 
 The sample usage can be found here: [app.py](src/app.py)
-
- 
-

--- a/enroll_certificates.py
+++ b/enroll_certificates.py
@@ -1,0 +1,47 @@
+import argparse
+
+from src.openbanking_tpp_proxy.proxy import Proxy
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Process parametes for certificate enrollment")
+
+    parser.add_argument('--api_url', type=str, required=True,
+                        help='API url needed for certificate integration')
+    parser.add_argument('--tpp_id', type=str, required=True,
+                        help="ID of the TPP certificate which can be found under 'subject=*'.")
+    parser.add_argument('--tpp_name', type=str, required=True,
+                        help="Name of TPP used for integration purposes.")
+    parser.add_argument('--qwac_cert', type=str, required=True,
+                        help="Path QWAC certificate in DER format.")
+    parser.add_argument('--qwac_key', type=str, required=True,
+                        help="Path QWAC key in PEM format.")
+    parser.add_argument('--qseal_cert', type=str, required=True,
+                        help="Path QSEAL certificate in DER format.")
+    parser.add_argument('--qseal_key', type=str, required=True,
+                        help="Path QSEAL key in PEM format.")
+    parser.add_argument('--intermediate_cert', type=str, required=True,
+                        help="Path intermediate certificate in DER format.")
+    parser.add_argument('--root_cert', type=str, required=True,
+                        help="Path root certificate in DER format.")
+
+    args = parser.parse_args()
+
+    # Enrollment process
+    proxy = Proxy(args.qwac_cert, args.qwac_key, args.qseal_cert, args.qseal_key)
+    enrollment_path = args.api_url + "/eidas/1.0/v1/enrollment"
+    enrollment_response = proxy.enroll_certificates(enrollment_path,
+                                                    args.intermediate_cert,
+                                                    args.root_cert,
+                                                    args.tpp_id,
+                                                    args.tpp_name)
+    print(enrollment_response.status_code)
+    print(enrollment_response.content)
+
+    # Perform connection checks
+    response = proxy.proxy_request("GET", args.api_url + "/eidas/1.0/v1/consents/health-check")
+    print(response.status_code)
+    print(response.content)
+
+    response = proxy.proxy_request("GET", args.api_url + "/eidas/1.0/v1/payments/health-check")
+    print(response.status_code)
+    print(response.content)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 # replace with your username:
 name = openbanking-tpp-client-python
-version = 0.0.1
+version = 0.1.0
 author = Przemyslaw Palak
 author_email = przemek@palak.pl
 description = A tpp client library to call PSD2 API, taking care of security setup

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name=" openbanking-tpp-client-python",
+    name="openbanking-tpp-client-python",
     version="0.0.1",
     author="Przemyslaw Palak",
     author_email="przemek@palak.pl",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="openbanking-tpp-client-python",
-    version="0.0.1",
+    version="0.1.0",
     author="Przemyslaw Palak",
     author_email="przemek@palak.pl",
     description="A tpp client library to call PSD2 API, taking care of security setup",

--- a/src/app.py
+++ b/src/app.py
@@ -6,9 +6,9 @@ if __name__ == "__main__":
     #put tpp id from cert file here
     tpp_id = ""
     proxy = Proxy("qwac_cert.cer", "qwac_key.key", "qseal_cert.cer", "qseal_key.key")
-    enrolmentResponse = proxy.enroll_certificates(api_url + "/eidas/1.0/v1/enrollment", "intermediate.cer", "root.cer", tpp_id, "Awsome tpp")
-    print(enrolmentResponse.status_code)
-    print(enrolmentResponse.content)
+    enrollment_response = proxy.enroll_certificates(api_url + "/eidas/1.0/v1/enrollment", "intermediate.cer", "root.cer", tpp_id, "Awsome tpp")
+    print(enrollment_response.status_code)
+    print(enrollment_response.content)
     response = proxy.proxy_request("GET", api_url + "/eidas/1.0/v1/consents/health-check")
     print(response.status_code)
     print(response.content)

--- a/src/app.py
+++ b/src/app.py
@@ -6,7 +6,7 @@ if __name__ == "__main__":
     #put tpp id from cert file here
     tpp_id = ""
     proxy = Proxy("qwac_cert.cer", "qwac_key.key", "qseal_cert.cer", "qseal_key.key")
-    enrollment_response = proxy.enroll_certificates(api_url + "/eidas/1.0/v1/enrollment", "intermediate.cer", "root.cer", tpp_id, "Awsome tpp")
+    enrollment_response = proxy.enroll_certificates(api_url + "/eidas/1.0/v1/enrollment", "intermediate.cer", "root.cer", tpp_id, "Awesome tpp")
     print(enrollment_response.status_code)
     print(enrollment_response.content)
     response = proxy.proxy_request("GET", api_url + "/eidas/1.0/v1/consents/health-check")


### PR DESCRIPTION
This PR provides changes:

- Addition of `enroll_certificates.py` python script which uses standard library `argparse` (no external dependencies added) to provide argument parsing and easy TPP certificate upload. It is based on example of `src/app.py`. Usage docs are included in readme.
- Fix to `setup.py` - whitespace causing installation to fail.
- Change to camel case standard in `src/app.py` (minor change).
- Minor tweaks (Markdown standard) to readme and installation instructions for python `setuptools` usage.
- Version bump.