### PR TITLE
Add proxy and optional arguments support to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,26 @@ python enroll_certificates.py \
   --root_cert "root.cer"
 ```
 
+Optionally when you need to use proxy or QSEAL key password, you can append optional parameters.
+
+**Example**
+
+```bash
+python enroll_certificates.py \
+  --http_proxy "http://example.com:8080" \
+  --https_proxy "https://example.com:8080" \
+  --api_url http://example.com
+  --tpp_id "NO-12345-ABC" \
+  --tpp_name "Awesome TPP" \
+  --qwac_cert "qwac_cert.cer" \
+  --qwac_key "qwac_key.key" \
+  --qseal_cert "qseal_cert.cer" \
+  --qseal_key "qseal_key.key" \
+  --qseal_key_file_password "QSEAL KEY SECRET PASSWORD" \
+  --intermediate_cert "intermediate.cer" \
+  --root_cert "root.cer"
+```
+
 #### Help
 
 To display help and information about arguments.

--- a/enroll_certificates.py
+++ b/enroll_certificates.py
@@ -23,11 +23,33 @@ if __name__ == '__main__':
                         help="Path intermediate certificate in DER format.")
     parser.add_argument('--root_cert', type=str, required=True,
                         help="Path root certificate in DER format.")
+    # Optional arguments
+    parser.add_argument('--qseal_key_file_password',
+                        default=None,
+                        type=str,
+                        required=False,
+                        help="(OPTIONAL) Password to qseal key file.")
+    parser.add_argument('--http_proxy',
+                        default=None,
+                        type=str,
+                        required=False,
+                        help="(OPTIONAL) HTTP proxy URI with port.")
+    parser.add_argument('--https_proxy',
+                        default=None,
+                        type=str,
+                        required=False,
+                        help="(OPTIONAL) HTTPS proxy URI with port.")
 
     args = parser.parse_args()
 
     # Enrollment process
-    proxy = Proxy(args.qwac_cert, args.qwac_key, args.qseal_cert, args.qseal_key)
+    proxy = Proxy(args.qwac_cert,
+                  args.qwac_key,
+                  args.qseal_cert,
+                  args.qseal_key,
+                  args.qseal_key_file_password,
+                  args.http_proxy,
+                  args.https_proxy)
     enrollment_path = args.api_url + "/eidas/1.0/v1/enrollment"
     enrollment_response = proxy.enroll_certificates(enrollment_path,
                                                     args.intermediate_cert,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 # replace with your username:
 name = openbanking-tpp-client-python
-version = 0.1.0
+version = 0.2.0
 author = Przemyslaw Palak
 author_email = przemek@palak.pl
 description = A tpp client library to call PSD2 API, taking care of security setup

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="openbanking-tpp-client-python",
-    version="0.1.0",
+    version="0.2.0",
     author="Przemyslaw Palak",
     author_email="przemek@palak.pl",
     description="A tpp client library to call PSD2 API, taking care of security setup",

--- a/src/openbanking_tpp_proxy/proxy.py
+++ b/src/openbanking_tpp_proxy/proxy.py
@@ -15,8 +15,10 @@ from cryptography.hazmat.primitives.asymmetric import padding
 class Proxy(object):
 
     def __init__(self, qwac_cert_file_path, qwac_key_file_path, qseal_cert_file_path, qseal_key_file_path,
-                 qseal_key_file_password=None) -> None:
+                 qseal_key_file_password=None, http_proxy=None, https_proxy=None) -> None:
         super().__init__()
+        self.http_proxy = http_proxy
+        self.https_proxy = https_proxy
         self.pk_password = qseal_key_file_password
         self.cert = (qwac_cert_file_path, qwac_key_file_path)
         self.qseal_key_file_path = qseal_key_file_path
@@ -98,6 +100,14 @@ class Proxy(object):
             "Content-Type": "application/json",
             "TPP-Signature-Certificate": self.tpp_sig_cert
         }
+
+        if self.http_proxy or self.https_proxy:
+            proxies = {
+                "http": self.http_proxy,
+                "https": self.https_proxy
+            }
+            return requests.request(method, api_url, data=body, verify=False, cert=self.cert, headers=headers, proxies=proxies)
+
         return requests.request(method, api_url, data=body, verify=False, cert=self.cert, headers=headers)
 
     def enroll_certificates(self, enrolment_url, ca_interm_file_path, ca_root_file_path, tppId, commercial_name,


### PR DESCRIPTION
### Non breaking changes 

- [x] Support for HTTP and HTTPS proxies for enrollment request via cli
- [x] Support for `qseal_key_file_password` argument from CLI
- [x] Readme updates 
- [x] Version bump